### PR TITLE
Fix possible memory corruption after realloc and memory leaks

### DIFF
--- a/toxcore/group_chats.c
+++ b/toxcore/group_chats.c
@@ -4429,6 +4429,8 @@ static int peer_add(Messenger *m, int groupnumber, IP_Port *ipp, const uint8_t *
             return -1;
     }
 
+    chat->gcc = tmp_gcc;
+
     GC_Connection *tmp_gcc = realloc(chat->gcc, sizeof(GC_Connection) * (chat->numpeers + 1));
 
     if (tmp_gcc == NULL) {
@@ -4448,7 +4450,6 @@ static int peer_add(Messenger *m, int groupnumber, IP_Port *ipp, const uint8_t *
     memset(&tmp_group[peernumber], 0, sizeof(GC_GroupPeer));
     memset(&tmp_gcc[peernumber], 0, sizeof(GC_Connection));
 
-    chat->gcc = tmp_gcc;
     chat->group = tmp_group;
 
     GC_Connection *gconn = &chat->gcc[peernumber];

--- a/toxcore/group_moderation.c
+++ b/toxcore/group_moderation.c
@@ -60,8 +60,15 @@ int mod_list_unpack(GC_Chat *chat, const uint8_t *data, uint32_t length, uint32_
     for (i = 0; i < num_mods; ++i) {
         tmp_list[i] = malloc(sizeof(uint8_t) * GC_MOD_LIST_ENTRY_SIZE);
 
-        if (tmp_list[i] == NULL)
+        if (tmp_list[i] == NULL) {
+            uint16_t j;
+            for (j = 0; j < i; ++j)
+                free(tmp_list[j]);
+
+            free(tmp_list);
+
             return -1;
+        }
 
         memcpy(tmp_list[i], &data[i * GC_MOD_LIST_ENTRY_SIZE], GC_MOD_LIST_ENTRY_SIZE);
         unpacked_len += GC_MOD_LIST_ENTRY_SIZE;

--- a/toxcore/group_moderation.c
+++ b/toxcore/group_moderation.c
@@ -220,10 +220,10 @@ int mod_list_add_entry(GC_Chat *chat, const uint8_t *mod_data)
 
     uint8_t **tmp_list = realloc(chat->moderation.mod_list, sizeof(uint8_t *) * (chat->moderation.num_mods + 1));
 
-    if (tmp_list == NULL) {
-        chat->moderation.num_mods = 0;
+    if (tmp_list == NULL)
         return -1;
-    }
+
+    chat->moderation.mod_list = tmp_list;
 
     tmp_list[chat->moderation.num_mods] = malloc(sizeof(uint8_t) * GC_MOD_LIST_ENTRY_SIZE);
 
@@ -231,7 +231,6 @@ int mod_list_add_entry(GC_Chat *chat, const uint8_t *mod_data)
         return -1;
 
     memcpy(tmp_list[chat->moderation.num_mods], mod_data, GC_MOD_LIST_ENTRY_SIZE);
-    chat->moderation.mod_list = tmp_list;
     ++chat->moderation.num_mods;
 
     return 0;


### PR DESCRIPTION
realloc can move memory block, so if we do not store pointer to it (if next malloc/realloc failed) we can get pointer to invalid memory block and crash application on next access.
