### PR TITLE
Use the group password only through a KDF

### DIFF
--- a/auto_tests/group_save_test.c
+++ b/auto_tests/group_save_test.c
@@ -61,17 +61,6 @@ static int has_correct_group_state(const Tox *tox, uint32_t group_number, const 
         return -1;
     }
 
-    size_t pass_len = tox_group_get_password_size(tox, group_number, &query_err);
-    ck_assert(query_err == TOX_ERR_GROUP_STATE_QUERIES_OK);
-
-    uint8_t password[TOX_GROUP_MAX_PASSWORD_SIZE];
-    tox_group_get_password(tox, group_number, password, &query_err);
-    ck_assert(query_err == TOX_ERR_GROUP_STATE_QUERIES_OK);
-
-    if (pass_len != PASS_LEN || memcmp(password, PASSWORD, pass_len) != 0) {
-        return -2;
-    }
-
     size_t gname_len = tox_group_get_name_size(tox, group_number, &query_err);
     ck_assert(query_err == TOX_ERR_GROUP_STATE_QUERIES_OK);
 

--- a/auto_tests/group_state_test.c
+++ b/auto_tests/group_state_test.c
@@ -102,21 +102,12 @@ static void group_peer_limit_handler(Tox *tox, uint32_t groupnumber, uint32_t pe
                   "Peer limits don't match in callback: %u, %u\n", peer_limit, current_plimit);
 }
 
-static void group_password_handler(Tox *tox, uint32_t groupnumber, const uint8_t *password, size_t length,
+static void group_password_handler(Tox *tox, uint32_t group_number, Tox_Group_Password_Status status,
                                    void *user_data)
 {
+    /* TODO: test this callback */
     Tox_Err_Group_State_Queries err;
-    size_t curr_pwlength = tox_group_get_password_size(tox, groupnumber, &err);
 
-    ck_assert(err == TOX_ERR_GROUP_STATE_QUERIES_OK);
-    ck_assert(length == curr_pwlength);
-
-    uint8_t current_password[TOX_GROUP_MAX_PASSWORD_SIZE];
-    tox_group_get_password(tox, groupnumber, current_password, &err);
-
-    ck_assert(err == TOX_ERR_GROUP_STATE_QUERIES_OK);
-    ck_assert_msg(memcmp(current_password, password, length) == 0,
-                  "Passwords don't match: %s, %s", password, current_password);
 }
 
 static void group_peer_join_handler(Tox *tox, uint32_t group_number, uint32_t peer_id, void *user_data)
@@ -151,26 +142,6 @@ static int check_group_state(const Tox *tox, uint32_t groupnumber, uint32_t peer
 
     if (my_peer_limit != peer_limit) {
         return -2;
-    }
-
-    size_t my_pass_len = tox_group_get_password_size(tox, groupnumber, &query_err);
-    ck_assert_msg(query_err == TOX_ERR_GROUP_STATE_QUERIES_OK, "Failed to get password size: %d", query_err);
-
-    if (my_pass_len != pass_len) {
-        return -5;
-    }
-
-    if (password != nullptr && my_pass_len > 0) {
-        ck_assert(my_pass_len <= TOX_GROUP_MAX_PASSWORD_SIZE);
-
-        uint8_t my_pass[TOX_GROUP_MAX_PASSWORD_SIZE];
-        tox_group_get_password(tox, groupnumber, my_pass, &query_err);
-        my_pass[my_pass_len] = 0;
-        ck_assert_msg(query_err == TOX_ERR_GROUP_STATE_QUERIES_OK, "Failed to get password: %d", query_err);
-
-        if (memcmp(my_pass, password, my_pass_len) != 0) {
-            return -6;
-        }
     }
 
     /* Group name should never change */

--- a/toxcore/group_chats.h
+++ b/toxcore/group_chats.h
@@ -432,9 +432,8 @@ int gc_set_peer_role(const Messenger *m, int group_number, uint32_t peer_id, Gro
  *
  * Returns 0 on success.
  * Returns -1 if the caller does not have sufficient permissions for the action.
- * Returns -2 if the password is too long.
+ * Returns -2 if the key derivation function failed on the password. Probably out of memory.
  * Returns -3 if the packet failed to send.
- * Returns -4 if malloc failed.
  */
 non_null(1) nullable(2)
 int gc_founder_set_password(GC_Chat *chat, const uint8_t *password, uint16_t password_length);

--- a/toxcore/group_common.h
+++ b/toxcore/group_common.h
@@ -21,7 +21,10 @@
 #define MAX_GC_TOPIC_SIZE 512
 #define MAX_GC_GROUP_NAME_SIZE 48
 #define MAX_GC_MESSAGE_SIZE 1372
-#define MAX_GC_PASSWORD_SIZE 32
+
+/* The number of bytes in a passkey for protected groups */
+#define GC_PASSKEY_SIZE 32
+
 #define MAX_GC_SAVED_INVITES 10
 #define MAX_GC_PEERS_DEFAULT 100
 #define MAX_GC_SAVED_TIMEOUTS 12
@@ -54,6 +57,12 @@ typedef enum Group_Exit_Type {
     GC_EXIT_TYPE_SYNC_ERR          = 0x05,  // Peer failed to sync with the group
     GC_EXIT_TYPE_NO_CALLBACK       = 0x06,  // The peer exit callback should not be triggered
 } Group_Exit_Type;
+
+/** Group password change type. */
+typedef enum Group_Password_Change_Type {
+    Group_Password_Change_Type_Changed = 0x00,  // Password was changed
+    Group_Password_Change_Type_Removed = 0x01,  // Password was removed
+} Group_Password_Change_Type;
 
 typedef struct GC_Exit_Info {
     uint8_t  part_message[MAX_GC_PART_MESSAGE_SIZE];
@@ -214,8 +223,8 @@ typedef struct GC_SharedState {
     uint16_t    group_name_len;
     uint8_t     group_name[MAX_GC_GROUP_NAME_SIZE];
     Group_Privacy_State privacy_state;   // GI_PUBLIC (uses DHT) or GI_PRIVATE (invite only)
-    uint16_t    password_length;
-    uint8_t     password[MAX_GC_PASSWORD_SIZE];
+    bool        has_passkey;
+    uint8_t     passkey[CRYPTO_HMAC_SIZE];
     uint8_t     mod_list_hash[MOD_MODERATION_HASH_SIZE];
     uint32_t    topic_lock; // non-zero value when lock is enabled
     Group_Voice_State voice_state;
@@ -323,7 +332,7 @@ typedef void gc_topic_lock_cb(const Messenger *m, uint32_t group_number, unsigne
 typedef void gc_voice_state_cb(const Messenger *m, uint32_t group_number, unsigned int voice_state, void *user_data);
 typedef void gc_peer_limit_cb(const Messenger *m, uint32_t group_number, uint32_t max_peers, void *user_data);
 typedef void gc_privacy_state_cb(const Messenger *m, uint32_t group_number, unsigned int state, void *user_data);
-typedef void gc_password_cb(const Messenger *m, uint32_t group_number, const uint8_t *data, size_t length,
+typedef void gc_password_cb(const Messenger *m, uint32_t group_number, Group_Password_Change_Type password_change,
                             void *user_data);
 typedef void gc_peer_join_cb(const Messenger *m, uint32_t group_number, uint32_t peer_id, void *user_data);
 typedef void gc_peer_exit_cb(const Messenger *m, uint32_t group_number, uint32_t peer_id, unsigned int exit_type,

--- a/toxcore/group_pack.c
+++ b/toxcore/group_pack.c
@@ -35,7 +35,7 @@ static bool load_unpack_state_values(GC_Chat *chat, Bin_Unpack *bu)
             && bin_unpack_u16(bu, &chat->shared_state.group_name_len)
             && bin_unpack_u08(bu, &privacy_state)
             && bin_unpack_u16(bu, &chat->shared_state.maxpeers)
-            && bin_unpack_u16(bu, &chat->shared_state.password_length)
+            && bin_unpack_bool(bu, &chat->shared_state.has_passkey)
             && bin_unpack_u32(bu, &chat->shared_state.version)
             && bin_unpack_u32(bu, &chat->shared_state.topic_lock)
             && bin_unpack_u08(bu, &voice_state))) {
@@ -61,7 +61,7 @@ static bool load_unpack_state_bin(GC_Chat *chat, Bin_Unpack *bu)
     if (!(bin_unpack_bin_fixed(bu, chat->shared_state_sig, SIGNATURE_SIZE)
             && bin_unpack_bin_fixed(bu, chat->shared_state.founder_public_key, EXT_PUBLIC_KEY_SIZE)
             && bin_unpack_bin_fixed(bu, chat->shared_state.group_name, chat->shared_state.group_name_len)
-            && bin_unpack_bin_fixed(bu, chat->shared_state.password, chat->shared_state.password_length)
+            && bin_unpack_bin_fixed(bu, chat->shared_state.passkey, GC_PASSKEY_SIZE)
             && bin_unpack_bin_fixed(bu, chat->shared_state.mod_list_hash, MOD_MODERATION_HASH_SIZE))) {
         LOGGER_ERROR(chat->log, "Failed to unpack state binary data");
         return false;
@@ -271,7 +271,7 @@ static void save_pack_state_values(const GC_Chat *chat, Bin_Pack *bp)
     bin_pack_u16(bp, chat->shared_state.group_name_len); // 2
     bin_pack_u08(bp, chat->shared_state.privacy_state); // 3
     bin_pack_u16(bp, chat->shared_state.maxpeers); // 4
-    bin_pack_u16(bp, chat->shared_state.password_length); // 5
+    bin_pack_bool(bp, chat->shared_state.has_passkey); // 5
     bin_pack_u32(bp, chat->shared_state.version); // 6
     bin_pack_u32(bp, chat->shared_state.topic_lock); // 7
     bin_pack_u08(bp, chat->shared_state.voice_state); // 8
@@ -285,7 +285,7 @@ static void save_pack_state_bin(const GC_Chat *chat, Bin_Pack *bp)
     bin_pack_bin(bp, chat->shared_state_sig, SIGNATURE_SIZE); // 1
     bin_pack_bin(bp, chat->shared_state.founder_public_key, EXT_PUBLIC_KEY_SIZE); // 2
     bin_pack_bin(bp, chat->shared_state.group_name, chat->shared_state.group_name_len); // 3
-    bin_pack_bin(bp, chat->shared_state.password, chat->shared_state.password_length); // 4
+    bin_pack_bin(bp, chat->shared_state.passkey, GC_PASSKEY_SIZE); // 4
     bin_pack_bin(bp, chat->shared_state.mod_list_hash, MOD_MODERATION_HASH_SIZE); // 5
 }
 

--- a/toxcore/tox.h
+++ b/toxcore/tox.h
@@ -4276,35 +4276,29 @@ typedef void tox_group_peer_limit_cb(Tox *tox, uint32_t group_number, uint32_t p
 void tox_callback_group_peer_limit(Tox *tox, tox_group_peer_limit_cb *callback);
 
 /**
- * Return the length of the group password. If the group number is invalid, the
- * return value is unspecified.
+ * Status codes for group password updates.
  */
-size_t tox_group_get_password_size(const Tox *tox, uint32_t group_number, Tox_Err_Group_State_Queries *error);
+typedef enum Tox_Group_Password_Status {
 
-/**
- * Write the password for the group designated by the given group number to a byte array.
- *
- * Call tox_group_get_password_size to determine the allocation size for the `password` parameter.
- *
- * The data received is equal to the data received by the last
- * `group_password` callback.
- *
- * @see the `Group chat founder controls` section for the respective set function.
- *
- * @param password A valid memory region large enough to store the group password.
- *   If this parameter is NULL, this function call has no effect.
- *
- * @return true on success.
- */
-bool tox_group_get_password(const Tox *tox, uint32_t group_number, uint8_t *password,
-                            Tox_Err_Group_State_Queries *error);
+    /**
+     * A password for the group was set or changed.
+     */
+    TOX_GROUP_PASSWORD_STATUS_CHANGED,
+
+    /**
+     * The password was removed from the group.
+     */
+    TOX_GROUP_PASSWORD_STATUS_REMOVED,
+
+} Tox_Group_Password_Status;
+
 
 /**
  * @param group_number The group number of the group for which the password has changed.
  * @param password The new group password.
  * @param length The length of the password.
  */
-typedef void tox_group_password_cb(Tox *tox, uint32_t group_number, const uint8_t *password, size_t length,
+typedef void tox_group_password_cb(Tox *tox, uint32_t group_number, Tox_Group_Password_Status status,
                                    void *user_data);
 
 


### PR DESCRIPTION
This changes the NGC protocol in the following ways:

- The password is turned into a "passkey" through a Key Derivation Function (KDF), which uses the group public id as a salt.
- The API is changed such that the password can not be read from the group again

This has the following advantages:

- The "password" will no longer be stored in RAM in plaintext, although getting access to the group shared state will still allow access to the group. It will now be impossible to get what was used as the current group password in plaintext.
- Allows arbitrarily long passwords, although at the cost of having to always transmit 32bytes for packets where the group password used to be. (IMHO that's not really relevant, as the password was up to (1 to 32)+2 bytes)
- It's good practice to never use plaintext passwords in protocols as far as possible. This PR shows that it's possible, so I'm strongly in favor of implementing these changes to the NGC protocol.

This has the following disadvantages:

- The plaintext password will no longer be known to the whole group once the founder changes it. If peers should be able to invite other peers the plaintext password must be redistributed via some way. IMO this could also be a good feature, allowing the founder to invite people to the group and at some point "closing" the group for new invites by changing the password. An option to workaround this problem would be to allow the founder to optionally send a broadcast to the group (or to select people in the group) with the plaintext password. It really depends on what we want to do though.

In this PR I implemented a PoC on what changes would be needed. It is not fully complete and I think I broke packet encoding somewhere, but it should suffice to show that this doesn't increase the complexity.